### PR TITLE
fix(shorthands): explodes margin/padding shorthands

### DIFF
--- a/aliases.js
+++ b/aliases.js
@@ -60,7 +60,7 @@ const aliases = {
     unit: str
   },
   m: {
-    properties: ['margin'],
+    properties: ['marginTop', 'marginBottom', 'marginLeft', 'marginRight'],
     scale: 'space',
     unit: px
   },
@@ -95,7 +95,7 @@ const aliases = {
     unit: px
   },
   p: {
-    properties: ['padding'],
+    properties: ['paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight'],
     scale: 'space',
     unit: px
   },

--- a/test/digest.test.js
+++ b/test/digest.test.js
@@ -162,4 +162,50 @@ module.exports = (test, assert) => {
     )
     assert.equal(style.top, '-2px')
   })
+
+  test('exploded props', () => {
+    const { style } = digest(
+      {
+        p: 1,
+        m: 1
+      },
+      {
+        space: [0, 2]
+      }
+    )
+    assert.equal(style.paddingTop, '2px')
+    assert.equal(style.paddingBottom, '2px')
+    assert.equal(style.paddingLeft, '2px')
+    assert.equal(style.paddingRight, '2px')
+
+    assert.equal(style.marginTop, '2px')
+    assert.equal(style.marginBottom, '2px')
+    assert.equal(style.marginLeft, '2px')
+    assert.equal(style.marginRight, '2px')
+  })
+
+  test('margin/padding precendence', () => {
+    const { style } = digest(
+      {
+        pl: 0,
+        p: 1,
+        pr: 0,
+        ml: 0,
+        m: 1,
+        mr: 0
+      },
+      {
+        space: [0, 2]
+      }
+    )
+    assert.equal(style.paddingTop, '2px')
+    assert.equal(style.paddingBottom, '2px')
+    assert.equal(style.paddingLeft, '2px')
+    assert.equal(style.paddingRight, '0px')
+
+    assert.equal(style.marginTop, '2px')
+    assert.equal(style.marginBottom, '2px')
+    assert.equal(style.marginLeft, '2px')
+    assert.equal(style.marginRight, '0px')
+  })
 }


### PR DESCRIPTION
Prevents styletron error + allows for prop precendence to override directional values.

fix #4